### PR TITLE
Named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Illuminate Container 
+# Illuminate Container
 
 A powerful IoC container for PHP.
 


### PR DESCRIPTION
I think it would be helpful to support named parameters. Instead of bombing out on a primitive type, why not check if a named parameter is supplied for that type? The example included in the tests illustrates this:

``` php
$container = new Container;
$container->bind('IContainerContractStub', 'ContainerImplementationStub');
$concrete = 'ContainerDependentStubWithParams';
$args = array('one', 'two');
$container->withParam($concrete, 'args', $args);

$class = $container->make($concrete);
```

I implemented this as a result of trying to introduce a DI approach in an old Zend Framework 1 application, as those controllers have the following signature:

``` php
public function __construct(
    Zend_Controller_Request_Abstract $request, 
   Zend_Controller_Response_Abstract $response, 
   array $invokeArgs = array())
```
