### PR TITLE
added container closure binding resolving feature

### DIFF
--- a/Container.php
+++ b/Container.php
@@ -726,7 +726,7 @@ class Container implements ArrayAccess, ContainerContract
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            return $concrete($this, $parameters);
+            return $this->call( $concrete );
         }
 
         $reflector = new ReflectionClass($concrete);

--- a/Container.php
+++ b/Container.php
@@ -726,7 +726,7 @@ class Container implements ArrayAccess, ContainerContract
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            return $this->call( $concrete );
+            return $this->call( $concrete, $parameters );
         }
 
         $reflector = new ReflectionClass($concrete);


### PR DESCRIPTION
## instead of having to bind like this

``` php
$container->bind( 'articles\\title', function( Container $container )
{   
    $request = $container->make( 'Lionar\\Kernel\\Request' );
    $title = $container->make( 'Eyedouble\\Messages\\Title' );
    $text = $container->make( 'Eyedouble\\Messages\\Text' );
    return $title->with( $text( $request->request->get( 'title' ) ) );
} );
```
## you will be able to bind like this

``` php
use Eyedouble\Messages\Text,
    Eyedouble\Messages\Title,
    Lionar\Kernel\Request;

$container->bind( 'articles\\title', function( Request $request, Title $title, Text $text )
{   
    return $title->with( $text( $request->request->get( 'title' ) ) );
} );
```
## injecting the container in here will still be possible

``` php
use Illuminate\Container\Container;

$container = new Container;
$container->instance( 'Illuminate\\Container\\Container', $container );

$container->bind( 'WORKED', function( )
{
    return 'IT WORKED';
} );


$container->bind( 'test', function( Container $container )
{   
    var_dump( $container );
    var_dump( $container->make( 'WORKED' ) );
} );

$container->make( 'test' );
```
